### PR TITLE
Add triage label mapping (ready-for-agent/human collapsed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 Issues live in this repo's GitHub Issues (guntherjh/guntherjh.github.io); skills use the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
+### Triage labels
+
+Custom vocabulary: `ready-for-agent`/`ready-for-human` are collapsed into one label, `ready-to-implement`. See `docs/agents/triage-labels.md`.
+
 ### Domain docs
 
 Single-context: root `CONTEXT.md` + `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| --------------------------- | --------------------- | ----------------------------------------- |
+| `needs-triage`               | `needs-triage`         | Maintainer needs to evaluate this issue   |
+| `needs-info`                 | `needs-info`           | Waiting on reporter for more information  |
+| `ready-for-agent`            | `ready-to-implement`   | Fully specified, ready for an AFK agent   |
+| `ready-for-human`            | `ready-to-implement`   | Requires human implementation             |
+| `wontfix`                    | `wontfix`               | Will not be actioned                      |
+
+`ready-for-agent` and `ready-for-human` are deliberately collapsed into one label, `ready-to-implement` — this repo doesn't distinguish agent-workable from human-only tickets by label. If that distinction ever matters (e.g. a ticket genuinely needs a human judgment call), say so in the ticket body rather than relying on the label.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.


### PR DESCRIPTION
Corrects an earlier `/setup-matt-pocock-skills` run that concluded the `triage` skill wasn't installed (a too-shallow filesystem search missed it, it's actually installed alongside the other engineering skills). Adds the label vocabulary it needs.

This repo collapses `ready-for-agent` and `ready-for-human` into a single `ready-to-implement` label, since there's no meaningful agent/human distinction for a solo personal-site repo. `needs-triage`, `needs-info`, `wontfix` keep their canonical names.

- `docs/agents/triage-labels.md` — the role → label mapping
- `CLAUDE.md` — adds the "Triage labels" sub-section to the Agent skills block

🤖 Generated with [Claude Code](https://claude.com/claude-code)