### PR TITLE
Update About page work experience and bio

### DIFF
--- a/src/about.njk
+++ b/src/about.njk
@@ -5,15 +5,35 @@ layout: layouts/base.njk
 <h1>About</h1>
 
 <section class="bio">
-  <p>I am a front-end engineer who builds applications and components using JavaScript, HTML, and CSS. I love building cool things, especially using JavaScript. I have worked on small and large code bases and enjoy the unique challenges presented by both.</p>
+  <p>I am a front-end engineer who builds applications and components using JavaScript, HTML, and CSS. I love building cool things, especially using JavaScript. I have worked on small and large code bases and enjoy the unique challenges presented by both — today as a Senior Staff Frontend Engineer at Pendo.io.</p>
 </section>
 
 <section class="resume">
   <h2>Work Experience</h2>
 
   <article class="job">
+    <h3>Senior Staff Frontend Engineer <span class="where">· Pendo.io</span></h3>
+    <p class="dates">January 2026 – Present</p>
+  </article>
+
+  <article class="job">
+    <h3>Staff Frontend Engineer <span class="where">· Pendo.io</span></h3>
+    <p class="dates">August 2022 – January 2026</p>
+  </article>
+
+  <article class="job">
+    <h3>Senior Frontend Engineer <span class="where">· Pendo.io</span></h3>
+    <p class="dates">April 2020 – August 2022</p>
+  </article>
+
+  <article class="job">
+    <h3>Front-End Engineer <span class="where">· Pendo.io</span></h3>
+    <p class="dates">August 2017 – April 2020</p>
+  </article>
+
+  <article class="job">
     <h3>Front-End Developer <span class="where">· Prometheus Group</span></h3>
-    <p class="dates">November 2015 – Present</p>
+    <p class="dates">November 2015 – August 2017</p>
     <p>Main front-end resource for multiple web-based projects. Also responsible for training and mentoring junior developers working on the front-end code bases.</p>
     <ul>
       <li>Currently working on the research and development team invesitgating a complete rewrite of a Gantt chart based scheduling application. The prototypes are being built using TypeScript, React, Redux, and Webpack. I'm using techniques such as virtualized tables to handle renderring large data sets.</li>

--- a/src/about.njk
+++ b/src/about.njk
@@ -36,7 +36,7 @@ layout: layouts/base.njk
     <p class="dates">November 2015 – August 2017</p>
     <p>Main front-end resource for multiple web-based projects. Also responsible for training and mentoring junior developers working on the front-end code bases.</p>
     <ul>
-      <li>Currently working on the research and development team invesitgating a complete rewrite of a Gantt chart based scheduling application. The prototypes are being built using TypeScript, React, Redux, and Webpack. I'm using techniques such as virtualized tables to handle renderring large data sets.</li>
+      <li>Worked on the research and development team investigating a complete rewrite of a Gantt chart based scheduling application. The prototypes were built using TypeScript, React, Redux, and Webpack. I used techniques such as virtualized tables to handle rendering large data sets.</li>
       <li>Completely rewrote a legacy analytics application, porting the code base from ExtJS to React/Redux built using Webpack. It also went from having no test coverage to almost complete test coverage.</li>
       <li>Implemented mandatory coding standards, test coverage, and code reviews for all new front-end projects. This includes custom ESLint configurations and Git hooks.</li>
       <li>Created training documentation for interns and new hires working on the front-end code bases.</li>


### PR DESCRIPTION
Closes #2

Replaces the carried-forward 2015-era work history and bio on the About page with current information, per the ticket's acceptance criteria.

- Adds four Pendo.io entries (Front-End Engineer through Senior Staff Frontend Engineer, Aug 2017–Present), each with title/company/dates only — no highlight bullets yet, by explicit request; a later pass can add them
- Corrects the Prometheus Group entry's end date (was open-ended "Present", now Nov 2015 – Aug 2017) and rewrites its one bullet that was left in a dangling present tense after the date change (also fixed two incidental typos in that same sentence)
- Refreshes the bio's closing clause to mention the current role
- Education/Skills sections reviewed and left untouched — confirmed still accurate by the site owner

Reviewed via `/code-review` (Standards + Spec axes) before the tense fix; both axes' remaining findings are documented deferrals, not defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)