### PR TITLE
Fix accessibility/responsive gaps found in standards audit

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -9,6 +9,8 @@
   <link rel="alternate" type="application/rss+xml" title="{{ metadata.title }}" href="{{ metadata.url }}/feed.xml">
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
   <header class="site-header">
     <a class="site-title" href="/">{{ metadata.title }}</a>
     <nav class="site-nav">
@@ -18,7 +20,7 @@
     </nav>
   </header>
 
-  <main class="site-main">
+  <main class="site-main" id="main-content">
     {{ content | safe }}
   </main>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -30,6 +30,21 @@ a {
   color: var(--color-accent);
 }
 
+.skip-link {
+  position: absolute;
+  top: -3rem;
+  left: 0;
+  background: var(--color-accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  transition: top 0.1s ease-in-out;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 .site-header,
 .site-main,
 .site-footer {
@@ -119,8 +134,9 @@ h3 {
 
 .post-list li {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.25rem 1rem;
   padding: 0.5rem 0;
   border-bottom: 1px solid var(--color-border);
 }


### PR DESCRIPTION
Follow-up to #8: once CODING_STANDARDS.md landed, audited the existing site against it. Most of it was already compliant (zero JS in the site, semantic landmarks already in place, heading hierarchy clean, color contrast all passing AA/AAA). Two real gaps found and fixed here:

- No "skip to main content" link (WCAG 2.4.1 Bypass Blocks, Level A) — added, visually hidden until keyboard focus
- `.post-list li` had no `flex-wrap`, so a long post title next to its date could overflow on narrow screens once real posts exist — added `flex-wrap: wrap`

Not tied to a tracked issue, so no issue reference in the commit per the repo's commit convention (that only applies when a commit resolves a tracked issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)