### PR TITLE
Collapsible About page sections (About Me / About this site / Resume)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,14 @@ _Avoid_: Section
 A dated, chronological entry in the Blog. Distinct from a Page.
 _Avoid_: Article, entry
 
+**About Me**:
+The About page's subsection introducing who the site owner is, outside of career history.
+_Avoid_: Bio (as a section name), intro
+
+**About this site**:
+The About page's subsection describing the site itself — what it's built with and why it exists. Distinct from About Me.
+_Avoid_: Colophon, meta section
+
 **Resume**:
-The career-history content (work experience, education, skills) living as a section within the About page — not a standalone page.
+The About page's subsection covering career history (work experience, education, skills) and contact information.
 _Avoid_: CV, Resume page

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,6 +4,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addPlugin(pluginRss);
 
   eleventyConfig.addPassthroughCopy("src/css");
+  eleventyConfig.addPassthroughCopy("src/js");
   eleventyConfig.addPassthroughCopy({ "src/CNAME": "CNAME" });
 
   // Used by feed.njk so the RSS <updated> timestamp is always valid,

--- a/src/about.njk
+++ b/src/about.njk
@@ -4,131 +4,143 @@ layout: layouts/base.njk
 ---
 <h1>About</h1>
 
-<section class="bio">
+<details class="about-section" data-section="me">
+  <summary><h2>About Me</h2></summary>
   <p>I am a front-end engineer who builds applications and components using JavaScript, HTML, and CSS. I love building cool things, especially using JavaScript. I have worked on small and large code bases and enjoy the unique challenges presented by both — today as a Senior Staff Frontend Engineer at Pendo.io.</p>
-</section>
+</details>
 
-<section class="resume">
-  <h2>Work Experience</h2>
+<details class="about-section" data-section="site">
+  <summary><h2>About this site</h2></summary>
+  <p>Work in progress.</p>
+</details>
 
-  <article class="job">
-    <h3>Senior Staff Frontend Engineer <span class="where">· Pendo.io</span></h3>
-    <p class="dates">January 2026 – Present</p>
-  </article>
+<details class="about-section" data-section="resume">
+  <summary><h2>Resume</h2></summary>
 
-  <article class="job">
-    <h3>Staff Frontend Engineer <span class="where">· Pendo.io</span></h3>
-    <p class="dates">August 2022 – January 2026</p>
-  </article>
+  <section class="resume">
+    <h3>Work Experience</h3>
 
-  <article class="job">
-    <h3>Senior Frontend Engineer <span class="where">· Pendo.io</span></h3>
-    <p class="dates">April 2020 – August 2022</p>
-  </article>
+    <article class="job">
+      <h4>Senior Staff Frontend Engineer <span class="where">· Pendo.io</span></h4>
+      <p class="dates">January 2026 – Present</p>
+    </article>
 
-  <article class="job">
-    <h3>Front-End Engineer <span class="where">· Pendo.io</span></h3>
-    <p class="dates">August 2017 – April 2020</p>
-  </article>
+    <article class="job">
+      <h4>Staff Frontend Engineer <span class="where">· Pendo.io</span></h4>
+      <p class="dates">August 2022 – January 2026</p>
+    </article>
 
-  <article class="job">
-    <h3>Front-End Developer <span class="where">· Prometheus Group</span></h3>
-    <p class="dates">November 2015 – August 2017</p>
-    <p>Main front-end resource for multiple web-based projects. Also responsible for training and mentoring junior developers working on the front-end code bases.</p>
+    <article class="job">
+      <h4>Senior Frontend Engineer <span class="where">· Pendo.io</span></h4>
+      <p class="dates">April 2020 – August 2022</p>
+    </article>
+
+    <article class="job">
+      <h4>Front-End Engineer <span class="where">· Pendo.io</span></h4>
+      <p class="dates">August 2017 – April 2020</p>
+    </article>
+
+    <article class="job">
+      <h4>Front-End Developer <span class="where">· Prometheus Group</span></h4>
+      <p class="dates">November 2015 – August 2017</p>
+      <p>Main front-end resource for multiple web-based projects. Also responsible for training and mentoring junior developers working on the front-end code bases.</p>
+      <ul>
+        <li>Worked on the research and development team investigating a complete rewrite of a Gantt chart based scheduling application. The prototypes were built using TypeScript, React, Redux, and Webpack. I used techniques such as virtualized tables to handle rendering large data sets.</li>
+        <li>Completely rewrote a legacy analytics application, porting the code base from ExtJS to React/Redux built using Webpack. It also went from having no test coverage to almost complete test coverage.</li>
+        <li>Implemented mandatory coding standards, test coverage, and code reviews for all new front-end projects. This includes custom ESLint configurations and Git hooks.</li>
+        <li>Created training documentation for interns and new hires working on the front-end code bases.</li>
+        <li>Helped advise the development team as they transitioned from SVN to Git, and from Redmine to Jira.</li>
+      </ul>
+    </article>
+
+    <article class="job">
+      <h4>Front-End Engineer II <span class="where">· Bronto Software</span></h4>
+      <p class="dates">May 2015 – November 2015</p>
+      <p>Dedicated front-end resource working with multiple teams, each responsible for a specific service.</p>
+      <ul>
+        <li>Worked on an application written in Angular used to create product recommendations. For this project, I was the lead front-end resource working with a team based in Europe.</li>
+        <li>Led a large refactor of existing Angular code. Added a build process (using Gulp) and a system for writing and running unit tests (Karma, Jasmine, and Gulp).</li>
+        <li>Worked on a team with 5 other front-end developers to build a new email message editor from the ground up. Built using Backbone.</li>
+        <li>Created a small libary for managing AJAX requests using ES6 promises.</li>
+      </ul>
+    </article>
+
+    <article class="job">
+      <h4>Front-End Engineer <span class="where">· Bronto Software</span></h4>
+      <p class="dates">July 2013 – November 2015</p>
+      <p>Responsible for building and maintaining the front-end code for the company's core application.</p>
+      <ul>
+        <li>First project was a total re-write of the front-end used in the segmentation system. This was ulitmately built using Backbone after evaluating a variety of other libraries/frameworks.</li>
+        <li>Led the effort to implement a front-end build process using Grunt.</li>
+        <li>Led the effort to modularize the JavaScript code used by the front-end team. Initially, I used AMD with requireJS, but ultimately switched to using commonJS with Browserify.</li>
+        <li>Implemented dependency management workflow for front-end code using Bower and NPM.</li>
+        <li>Set up the environment and developed the process for writing unit tests for the JavaScript code. Testing is now an integral part of the software development process for the front-end team and tests are run as part of a larger build process.</li>
+        <li>Developed and implemented a series of scripts used as Git hooks to ensure code quality prior to committing code. This includes style checks, linting, and a node script for comparing file mtimes.</li>
+      </ul>
+    </article>
+
+    <article class="job">
+      <h4>Technical Writer/eLearning Specialist <span class="where">· Bronto Software</span></h4>
+      <p class="dates">May 2008 – July 2013</p>
+      <p>Responsible for building the documentation system and maintaining the content.</p>
+      <ul>
+        <li>Developed an XML based documentation system from the ground up.</li>
+        <li>Used XSLT (via libxslt library built into PHP) to produce HTML help for the web application and print (PDF, Word) help from a single source.</li>
+        <li>Developed the front-end for the HTML help, including the main UI, a table of contents (using jQuery), tree navigation (using jQuery), and built-in search (using jQuery with Apache Solr as the search engine).</li>
+        <li>Wrote a series of shell scripts to manage producing each type of documentation output.</li>
+        <li>Maintained all of the API documentation for the company's SOAP API including all example code written in PHP and Python.</li>
+        <li>Managed a customer-facing product blog and served as editor for a team of contributors.</li>
+        <li>Created and edited a series of how-to videos explaining how to use various parts of the application.</li>
+      </ul>
+    </article>
+  </section>
+
+  <section class="education">
+    <h3>Education</h3>
+    <p><strong>University of Dayton</strong> — Bachelor, Journalism (2003 – 2007)</p>
+  </section>
+
+  <section class="skills">
+    <h3>Skills</h3>
+
+    <div class="skill-group">
+      <h4>JavaScript Development</h4>
+      <p>TypeScript, React, Redux, Backbone, Angular, jQuery, NodeJS</p>
+    </div>
+
+    <div class="skill-group">
+      <h4>JavaScript Testing</h4>
+      <p>Jest, Enzyme, React Storybook, Mocha, Chai, Expect, Sinon, Jasmine, Karma</p>
+    </div>
+
+    <div class="skill-group">
+      <h4>JavaScript Build Tools</h4>
+      <p>Webpack, Grunt, Gulp, ESLint, TSLint, Module Formats (AMD, CommonJS, UMD, ES2015), Module Loaders (RequireJS, Browserify, ES2015 via Babel)</p>
+    </div>
+
+    <div class="skill-group">
+      <h4>Web Development</h4>
+      <p>HTML, CSS, Sass, Less, Bootstrap 3, Bulma</p>
+    </div>
+
+    <div class="skill-group">
+      <h4>Additional Languages</h4>
+      <p>Elm, PHP, Python, XSLT, XQuery</p>
+    </div>
+
+    <div class="skill-group">
+      <h4>General</h4>
+      <p>GIT, SVN, Atlassian Suite (Jira/Bamboo, Confluence, Crucible), Gitlab, Guthub, FogBugz, Redmine, Jenkins</p>
+    </div>
+  </section>
+
+  <section class="contact">
+    <h3>Contact</h3>
     <ul>
-      <li>Worked on the research and development team investigating a complete rewrite of a Gantt chart based scheduling application. The prototypes were built using TypeScript, React, Redux, and Webpack. I used techniques such as virtualized tables to handle rendering large data sets.</li>
-      <li>Completely rewrote a legacy analytics application, porting the code base from ExtJS to React/Redux built using Webpack. It also went from having no test coverage to almost complete test coverage.</li>
-      <li>Implemented mandatory coding standards, test coverage, and code reviews for all new front-end projects. This includes custom ESLint configurations and Git hooks.</li>
-      <li>Created training documentation for interns and new hires working on the front-end code bases.</li>
-      <li>Helped advise the development team as they transitioned from SVN to Git, and from Redmine to Jira.</li>
+      <li>Email: <a href="mailto:{{ metadata.author.email }}">{{ metadata.author.email }}</a></li>
+      <li>GitHub: <a href="{{ metadata.github }}">github.com/guntherjh</a></li>
     </ul>
-  </article>
+  </section>
+</details>
 
-  <article class="job">
-    <h3>Front-End Engineer II <span class="where">· Bronto Software</span></h3>
-    <p class="dates">May 2015 – November 2015</p>
-    <p>Dedicated front-end resource working with multiple teams, each responsible for a specific service.</p>
-    <ul>
-      <li>Worked on an application written in Angular used to create product recommendations. For this project, I was the lead front-end resource working with a team based in Europe.</li>
-      <li>Led a large refactor of existing Angular code. Added a build process (using Gulp) and a system for writing and running unit tests (Karma, Jasmine, and Gulp).</li>
-      <li>Worked on a team with 5 other front-end developers to build a new email message editor from the ground up. Built using Backbone.</li>
-      <li>Created a small libary for managing AJAX requests using ES6 promises.</li>
-    </ul>
-  </article>
-
-  <article class="job">
-    <h3>Front-End Engineer <span class="where">· Bronto Software</span></h3>
-    <p class="dates">July 2013 – November 2015</p>
-    <p>Responsible for building and maintaining the front-end code for the company's core application.</p>
-    <ul>
-      <li>First project was a total re-write of the front-end used in the segmentation system. This was ulitmately built using Backbone after evaluating a variety of other libraries/frameworks.</li>
-      <li>Led the effort to implement a front-end build process using Grunt.</li>
-      <li>Led the effort to modularize the JavaScript code used by the front-end team. Initially, I used AMD with requireJS, but ultimately switched to using commonJS with Browserify.</li>
-      <li>Implemented dependency management workflow for front-end code using Bower and NPM.</li>
-      <li>Set up the environment and developed the process for writing unit tests for the JavaScript code. Testing is now an integral part of the software development process for the front-end team and tests are run as part of a larger build process.</li>
-      <li>Developed and implemented a series of scripts used as Git hooks to ensure code quality prior to committing code. This includes style checks, linting, and a node script for comparing file mtimes.</li>
-    </ul>
-  </article>
-
-  <article class="job">
-    <h3>Technical Writer/eLearning Specialist <span class="where">· Bronto Software</span></h3>
-    <p class="dates">May 2008 – July 2013</p>
-    <p>Responsible for building the documentation system and maintaining the content.</p>
-    <ul>
-      <li>Developed an XML based documentation system from the ground up.</li>
-      <li>Used XSLT (via libxslt library built into PHP) to produce HTML help for the web application and print (PDF, Word) help from a single source.</li>
-      <li>Developed the front-end for the HTML help, including the main UI, a table of contents (using jQuery), tree navigation (using jQuery), and built-in search (using jQuery with Apache Solr as the search engine).</li>
-      <li>Wrote a series of shell scripts to manage producing each type of documentation output.</li>
-      <li>Maintained all of the API documentation for the company's SOAP API including all example code written in PHP and Python.</li>
-      <li>Managed a customer-facing product blog and served as editor for a team of contributors.</li>
-      <li>Created and edited a series of how-to videos explaining how to use various parts of the application.</li>
-    </ul>
-  </article>
-</section>
-
-<section class="education">
-  <h2>Education</h2>
-  <p><strong>University of Dayton</strong> — Bachelor, Journalism (2003 – 2007)</p>
-</section>
-
-<section class="skills">
-  <h2>Skills</h2>
-
-  <div class="skill-group">
-    <h3>JavaScript Development</h3>
-    <p>TypeScript, React, Redux, Backbone, Angular, jQuery, NodeJS</p>
-  </div>
-
-  <div class="skill-group">
-    <h3>JavaScript Testing</h3>
-    <p>Jest, Enzyme, React Storybook, Mocha, Chai, Expect, Sinon, Jasmine, Karma</p>
-  </div>
-
-  <div class="skill-group">
-    <h3>JavaScript Build Tools</h3>
-    <p>Webpack, Grunt, Gulp, ESLint, TSLint, Module Formats (AMD, CommonJS, UMD, ES2015), Module Loaders (RequireJS, Browserify, ES2015 via Babel)</p>
-  </div>
-
-  <div class="skill-group">
-    <h3>Web Development</h3>
-    <p>HTML, CSS, Sass, Less, Bootstrap 3, Bulma</p>
-  </div>
-
-  <div class="skill-group">
-    <h3>Additional Languages</h3>
-    <p>Elm, PHP, Python, XSLT, XQuery</p>
-  </div>
-
-  <div class="skill-group">
-    <h3>General</h3>
-    <p>GIT, SVN, Atlassian Suite (Jira/Bamboo, Confluence, Crucible), Gitlab, Guthub, FogBugz, Redmine, Jenkins</p>
-  </div>
-</section>
-
-<section class="contact">
-  <h2>Contact</h2>
-  <ul>
-    <li>Email: <a href="mailto:{{ metadata.author.email }}">{{ metadata.author.email }}</a></li>
-    <li>GitHub: <a href="{{ metadata.github }}">github.com/guntherjh</a></li>
-  </ul>
-</section>
+<script src="/js/about-sections.js" defer></script>

--- a/src/about.njk
+++ b/src/about.njk
@@ -5,12 +5,12 @@ layout: layouts/base.njk
 <h1>About</h1>
 
 <details class="about-section" data-section="me">
-  <summary><h2>About Me</h2></summary>
+  <summary><h2>Me</h2></summary>
   <p>I am a front-end engineer who builds applications and components using JavaScript, HTML, and CSS. I love building cool things, especially using JavaScript. I have worked on small and large code bases and enjoy the unique challenges presented by both — today as a Senior Staff Frontend Engineer at Pendo.io.</p>
 </details>
 
 <details class="about-section" data-section="site">
-  <summary><h2>About this site</h2></summary>
+  <summary><h2>This site</h2></summary>
   <p>Work in progress.</p>
 </details>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -85,7 +85,8 @@ a {
 
 h1,
 h2,
-h3 {
+h3,
+h4 {
   line-height: 1.25;
 }
 
@@ -98,7 +99,7 @@ h3 {
   margin-bottom: 2rem;
 }
 
-.job h3 {
+.job h4 {
   margin-bottom: 0.25rem;
 }
 
@@ -117,7 +118,7 @@ h3 {
   margin-bottom: 1rem;
 }
 
-.skill-group h3 {
+.skill-group h4 {
   margin-bottom: 0.25rem;
   font-size: 1rem;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -128,6 +128,43 @@ h4 {
   color: var(--color-muted);
 }
 
+.about-section {
+  margin-bottom: 1rem;
+}
+
+.about-section > summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Safari/WebKit renders its own marker outside the list-style mechanism */
+.about-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Custom marker, guaranteed centered against the heading via flexbox
+   align-items — the native marker doesn't scale/center against a
+   larger nested heading's font metrics, this does. */
+.about-section > summary::before {
+  content: "▶";
+  display: inline-block;
+  font-size: 0.75em;
+  color: var(--color-muted);
+  transition: transform 0.15s ease;
+}
+
+.about-section[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.about-section > summary h2 {
+  display: inline;
+  margin: 0;
+}
+
 .post-list {
   list-style: none;
   padding: 0;

--- a/src/js/about-sections.js
+++ b/src/js/about-sections.js
@@ -1,0 +1,39 @@
+// Persists which About page sections (About Me / About this site / Resume)
+// are expanded across page loads via localStorage. Native vanilla JS, no
+// dependency — per CODING_STANDARDS.md, this is JS used only because native
+// <details> has no cross-page-load persistence mechanism of its own.
+//
+// Degrades gracefully: with JS disabled (or localStorage unavailable, e.g.
+// private browsing), sections still expand/collapse via native <details>
+// behavior — they just don't remember state between visits.
+(function () {
+  var STORAGE_KEY = "about-expanded-sections";
+  var sections = document.querySelectorAll(".about-section");
+
+  function loadExpanded() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveExpanded() {
+    var open = Array.prototype.filter
+      .call(sections, function (section) { return section.open; })
+      .map(function (section) { return section.dataset.section; });
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(open));
+    } catch (e) {
+      // localStorage unavailable — sections still work, just won't persist.
+    }
+  }
+
+  var expanded = loadExpanded();
+  sections.forEach(function (section) {
+    if (expanded.indexOf(section.dataset.section) !== -1) {
+      section.open = true;
+    }
+    section.addEventListener("toggle", saveExpanded);
+  });
+})();

--- a/src/js/about-sections.js
+++ b/src/js/about-sections.js
@@ -19,8 +19,8 @@
   }
 
   function saveExpanded() {
-    var open = Array.prototype.filter
-      .call(sections, function (section) { return section.open; })
+    var open = Array.from(sections)
+      .filter(function (section) { return section.open; })
       .map(function (section) { return section.dataset.section; });
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(open));

--- a/src/js/about-sections.js
+++ b/src/js/about-sections.js
@@ -7,8 +7,8 @@
 // private browsing), sections still expand/collapse via native <details>
 // behavior — they just don't remember state between visits.
 (function () {
-  var STORAGE_KEY = "about-expanded-sections";
-  var sections = document.querySelectorAll(".about-section");
+  const STORAGE_KEY = "about-expanded-sections";
+  const sections = document.querySelectorAll(".about-section");
 
   function loadExpanded() {
     try {
@@ -19,9 +19,9 @@
   }
 
   function saveExpanded() {
-    var open = Array.from(sections)
-      .filter(function (section) { return section.open; })
-      .map(function (section) { return section.dataset.section; });
+    const open = Array.from(sections)
+      .filter((section) => section.open )
+      .map((section) => section.dataset.section );
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(open));
     } catch (e) {
@@ -29,8 +29,8 @@
     }
   }
 
-  var expanded = loadExpanded();
-  sections.forEach(function (section) {
+  const expanded = loadExpanded();
+  sections.forEach((section) => {
     if (expanded.indexOf(section.dataset.section) !== -1) {
       section.open = true;
     }


### PR DESCRIPTION
Closes #11

Restructures the About page into three `<details>`/`<summary>` subsections — Me, This site, Resume (now including Contact) — collapsed by default, independently toggleable, with expanded state persisted across page loads via a small native JS module (`src/js/about-sections.js`, no dependency, `localStorage`). Degrades gracefully with JS disabled.

Built on the structure validated in the throwaway prototype (`prototype/about-collapsible-sections`, commit `9a11584`), written properly here: extracted to a real JS file, proper error handling, no prototype-only placeholders.

Went through a full `/code-review` round (both axes) plus two manual visual passes on the running dev server:
- Review caught a real bug (stale `.job h3`/`.skill-group h3` CSS selectors left over from the heading-hierarchy bump to `h4` — elements were rendering unstyled) and a minor JS style inconsistency — both fixed.
- Manual visual check caught the native disclosure marker not aligning against the larger nested `<h2>` — replaced with a custom flexbox-centered marker.

"About this site" reads "Work in progress" for now, per the site owner — real copy is future content work, not part of this ticket. `CONTEXT.md` updated with the About Me / About this site / Resume terms drafted during the grilling session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)