### PR TITLE
Add ADR-0003: required CI checks via branch protection

### DIFF
--- a/docs/adr/0003-required-ci-checks-via-branch-protection.md
+++ b/docs/adr/0003-required-ci-checks-via-branch-protection.md
@@ -1,0 +1,3 @@
+# Required CI checks (lint, format, build) via branch protection
+
+CODING_STANDARDS.md previously relied on a manual, unenforced "verify before committing" step, and master had zero branch protection — any PR could merge regardless of whether it built, linted, or was formatted correctly. We added ESLint (eslint:recommended) and Prettier as required GitHub Actions checks (lint, format, build — three separately-named jobs), with branch protection on master requiring all three to pass before merge. This trades a small amount of tooling/CI overhead for a personal, JS-light codebase against consistent enforcement instead of relying on memory alone.


### PR DESCRIPTION
Documents the decision reached in a grilling session before issue #13's implementation lands: ESLint + Prettier as required GitHub Actions checks (lint, format, build), enforced via branch protection on master.

See #13 for the implementation ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)