### PR TITLE
Run Biome's formatter on generated Snapshot JSON

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -12,7 +12,7 @@ Conventions this project follows in practice, written down so `/code-review` and
 - **Global data**: `src/_data/*.js` (e.g. `metadata.js`) for site-wide values — title, tagline, URLs, author info. Reference these via `{{ metadata.* }}` in templates rather than hardcoding them inline.
 - **Passthrough copy**: static assets that need to reach the output unprocessed (CSS, `CNAME`) are registered explicitly in `eleventy.config.js` via `addPassthroughCopy` — don't rely on implicit copying.
 - **ESM throughout**: `package.json` sets `"type": "module"`; config and data files use `import`/`export`, not `require`/`module.exports`.
-- **`scripts/`**: CI/build-time Node scripts that aren't Eleventy config or template data — distinct from `src/js/`, which is browser-shipped JS passthrough-copied to the output. `scripts/lighthouse-audit.mjs` and `scripts/strava-refresh.mjs` (see the JavaScript section below for both).
+- **`scripts/`**: CI/build-time Node scripts that aren't Eleventy config or template data — distinct from `src/js/`, which is browser-shipped JS passthrough-copied to the output. `scripts/lighthouse-audit.mjs` and `scripts/strava-refresh.mjs` (see the JavaScript section below for both), sharing `scripts/lib/format-json.mjs`.
 
 ## CSS
 

--- a/scripts/lib/format-json.mjs
+++ b/scripts/lib/format-json.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from "node:child_process";
+
+// Biome formats JSON with tabs (biome.json); plain JSON.stringify doesn't
+// match that, which the required `check` CI job would then reject —
+// running Biome's own formatter here guarantees byte-for-byte conformance
+// with whatever biome.json's settings currently say, rather than hand-
+// replicating them (discovered the hard way: this mismatch silently
+// blocked every generated Snapshot's auto-merge PR from ever passing
+// checks — see guntherjh/guntherjh.github.io#47). No `npx` prefix needed:
+// both callers run via `npm run <script>`, which already puts
+// node_modules/.bin (where `biome` lives) on PATH.
+export function formatWithBiome(path) {
+	execFileSync("biome", ["format", "--write", path]);
+}

--- a/scripts/lighthouse-audit.mjs
+++ b/scripts/lighthouse-audit.mjs
@@ -23,6 +23,7 @@ import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { launch } from "chrome-launcher";
 import lighthouse from "lighthouse";
+import { formatWithBiome } from "./lib/format-json.mjs";
 
 const BASE_URL = "https://johnhenrygunther.com";
 const PAGES = [
@@ -75,6 +76,7 @@ async function main() {
 
 		const snapshot = { capturedAt: new Date().toISOString(), pages };
 		await writeFile(OUTPUT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);
+		formatWithBiome(OUTPUT_PATH);
 		console.log(`Wrote ${OUTPUT_PATH}`);
 	} finally {
 		await chrome.kill();

--- a/scripts/strava-refresh.mjs
+++ b/scripts/strava-refresh.mjs
@@ -15,6 +15,7 @@
 import { execFileSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { formatWithBiome } from "./lib/format-json.mjs";
 
 const CLIENT_ID = process.env.STRAVA_CLIENT_ID;
 const CLIENT_SECRET = process.env.STRAVA_CLIENT_SECRET;
@@ -153,6 +154,7 @@ async function main() {
 		stats: buildStats(rawStats),
 	};
 	await writeFile(OUTPUT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);
+	formatWithBiome(OUTPUT_PATH);
 	console.log(`Wrote ${OUTPUT_PATH}`);
 }
 


### PR DESCRIPTION
## Summary

Follow-up within #47. The original PR-based fix for #47 (already merged) worked for landing a PR, but a real end-to-end test revealed the auto-created PR's required `check` job failed and blocked the merge forever — both `scripts/lighthouse-audit.mjs` and `scripts/strava-refresh.mjs` write their output with plain `JSON.stringify(..., null, 2)` (2-space indent), which doesn't match this repo's `biome.json` (tabs). This was never caught before because the original direct-push bug always failed earlier in the pipeline.

Fix: both scripts run Biome's own formatter on the file after writing it, via a new shared `scripts/lib/format-json.mjs` (extracted after `/code-review` flagged the inline duplication, with `.github/actions/land-data-pr` as precedent for factoring shared logic between these same two scripts). Also dropped an unnecessary `npx` prefix — this repo's own `package.json` scripts call `biome` directly, since `npm run` already puts `node_modules/.bin` on PATH.

## Verification

- `biome check` and `npx eleventy` pass clean.
- Exercised the extracted helper directly (not just via the full pipeline): converts a 2-space `JSON.stringify` sample to Biome's exact tab-indented output.
- Ran `/code-review` (Standards + Spec axes) — two judgement-call findings, both fixed (duplication extracted, `npx` dropped).

Once merged, the plan is to trigger a real end-to-end run again and confirm the auto-created PR actually passes `check` this time and merges — closing #47 only once that's confirmed, not before.