### PR TITLE
Fix RSS feed crash when a post exists

### DIFF
--- a/src/feed.njk
+++ b/src/feed.njk
@@ -20,7 +20,7 @@ eleventyExcludeFromCollections: true
 		<link href="{{ post.url | absoluteUrl(metadata.url) }}"/>
 		<updated>{{ post.date | dateToRfc3339 }}</updated>
 		<id>{{ post.url | absoluteUrl(metadata.url) }}</id>
-		<content type="html">{{ post.content | htmlToAbsoluteUrls(post.url, metadata.url) | safe }}</content>
+		<content type="html">{{ post.content | htmlToAbsoluteUrls(metadata.url) | safe }}</content>
 	</entry>
 	{%- endfor %}
 </feed>


### PR DESCRIPTION
Resolves #21.

## Root cause
`feed.njk` called `htmlToAbsoluteUrls(post.url, metadata.url)` — two explicit arguments. The plugin's actual filter signature is `(htmlContent, base, callback)`, a single `base` argument (Nunjucks auto-appends its own callback as the final positional arg at call time). With the extra argument, `metadata.url` landed in the `callback` parameter's slot and the real callback was silently dropped as a 4th argument — hence `TypeError: callback is not a function`, as soon as `collections.posts` was non-empty (i.e. as soon as any real post existed to iterate over in the feed template's loop).

Likely introduced by visually mimicking the neighboring `absoluteUrl(path, base)` filter call two lines up, which genuinely does take two arguments — a different filter with a different signature.

## Fix
Pass just `metadata.url` as the single `base` argument, matching the plugin's real signature.

## Verification
- Reproduced the crash pre-fix with a throwaway post under `src/posts/` and `npx eleventy` (removed after, not committed).
- Same repro post + build succeeds post-fix; `feed.xml`'s `<content>` correctly rewrites relative URLs (e.g. `/about/`) to absolute ones against `metadata.url`.
- `npm run check` (Biome) and `npm test` (Vitest) both pass.
- Reviewed via `/code-review`: 0 blocking findings on Standards or Spec.