### PR TITLE
Fix nav link alignment in the mobile menu panel

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -315,8 +315,19 @@ html[data-theme="dark"] .theme-toggle-thumb::before {
 		display: flex;
 	}
 
+	/* .site-nav's desktop rules (align-items: center, justify-content: end,
+	   flex-wrap: wrap, flex: 1) are all for a horizontal right-aligned bar;
+	   in the vertical panel they left every link centred on the nav's own
+	   shrink-to-widest-link width, so each one sat at a different x
+	   (guntherjh/guntherjh.github.io#125). Reset to a plain top-aligned
+	   stack that fills the panel width, so every link shares a left edge. */
 	.nav-toggle-panel .site-nav {
+		flex: 0 1 auto;
 		flex-direction: column;
+		flex-wrap: nowrap;
+		align-self: stretch;
+		align-items: stretch;
+		justify-content: flex-start;
 	}
 
 	.nav-toggle-panel .site-nav a {


### PR DESCRIPTION
Resolves https://github.com/guntherjh/guntherjh.github.io/issues/125.

## Problem

In the mobile hamburger panel, the nav links didn't share a left edge — "Resume" sat flush left while "Blog" was indented, etc.

## Cause

`.nav-toggle-panel .site-nav` only overrode `flex-direction` to `column`; the desktop bar's `align-items: center`, `justify-content: end`, `flex-wrap: wrap` and `flex: 1` stayed in effect. The nav box shrank to the width of its widest link and each link was centred within that box, so every link landed at a different x.

## Fix

Reset those properties in the panel (scoped to `@media (max-width: 640px)`): a non-growing, non-wrapping column that stretches to the panel width, items stretched and packed from the top. Desktop nav is untouched.

## Verification

- Headless Chrome at 514 / 375 / 320 px: all four links now report identical `left` and `width` (before: four different `left` values).
- Desktop (900 px): horizontal right-aligned nav unchanged.
- `npx eleventy` clean; Vitest 53/53; Biome clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)